### PR TITLE
moved Genie to test dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "SwagUI"
 uuid = "bf05d729-34b2-4f1f-a2f1-2452bece7ebc"
 authors = ["Jiacheng Zhang <zhangjiacheng54@gmail.com>"]
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
-Genie = "c43c736e-a2d1-11e8-161f-af95117fbd1e"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -12,5 +11,10 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 julia = "1.5, 1.6"
 JSON = "0.21.1"
-Genie = "1"
 HTTP = "0.8, 0.9"
+
+[extras]
+Genie = "c43c736e-a2d1-11e8-161f-af95117fbd1e"
+
+[targets]
+test = ["Genie"]

--- a/src/SwagUI.jl
+++ b/src/SwagUI.jl
@@ -8,17 +8,23 @@ include("Builders.jl")
 export Options, render_swagger
 
 """
-    render_swagger(swagger_doc::Union{Dict{String, Any}, Nothing})::String
+    render_swagger(swagger_doc::Union{Dict{String, Any}, Nothing};
+                   options=nothing, kw...)
 
 Render Swagger UI's HTML as `String`, based on the options passed in. If a vaid `swagger_doc` is passed,
 the `url` and `urls` in the `Options.swagger_options` are ignored by the UI. If `swagger_doc` is `nothing`,
 `url` or `urls` has to be included in the `Options.swagger_options`.
 
+Options can be passed as an `Options` struct or indirectly via keyword arguments (see `Options`).
+
 # Arguments
 Required:
 - `swagger_doc::Union{Dict{String, Any}, Nothing}` : The swagger specification file `swagger.json` as a `Dict{String, Any}`.
 """
-function render_swagger(swagger_doc::Union{Dict{String, Any}, Nothing}; options::Options=Options())::String
+function render_swagger(swagger_doc::Union{AbstractDict{<:AbstractString,<:Any}, Nothing};
+                        options::Union{Options,Nothing}=nothing, kw...)::String
+    isnothing(options) && (options = Options(;kw...))
+
     js_string = build_js_string(options, swagger_doc)
     html_string = build_html_string(options, js_string)
 

--- a/src/SwagUI.jl
+++ b/src/SwagUI.jl
@@ -1,7 +1,6 @@
 module SwagUI
 
 using JSON
-using Genie, Genie.Router
 
 include("Options.jl")
 include("Builders.jl")

--- a/test/app.jl
+++ b/test/app.jl
@@ -14,7 +14,7 @@ function serve_assets(path::String; excludes::Array{String, 1}=Array{String, 1}(
         for file in files
             if !(file in excludes)
                 route(file) do 
-                    serve_static_file(file, root=root)
+                    open(read, joinpath(root, file)) |> String
                 end
             end
         end
@@ -22,7 +22,7 @@ function serve_assets(path::String; excludes::Array{String, 1}=Array{String, 1}(
 end
 
 serve_assets(ASSETS_PATH)
-Genie.AppServer.startup(PORT, HOST; open_browser = false, verbose = true)
+Genie.AppServer.startup(PORT, HOST; open_browser = false, verbose = true, async = true)
 
 # basic settings
 swagger_document = JSON.parsefile(joinpath(ASSETS_PATH, "swagger.json"))


### PR DESCRIPTION
This PR moves Genie to test dependencies.  That is, Genie is now only a dependency for testing and does not need to be installed with SwagUI itself.  This lightens the dependency load for using SwagUI with simpler servers such as [Mux](https://github.com/JuliaWeb/Mux.jl).